### PR TITLE
Allow Probes with value `null`

### DIFF
--- a/hull/values.schema.json
+++ b/hull/values.schema.json
@@ -13446,6 +13446,9 @@
                 },
                 {
                     "type": "object"
+                },
+                {
+                    "type": "null"
                 }
             ],
             "additionalProperties": false


### PR DESCRIPTION
I've got quite a specific use-case :  I create Helm charts to be used by end-users. They have been designed so that they mostly have to edit values in `helm.config.specific`, and not directly Kubernetes objects. While this approach works mostly fine with Hull, there is a small issue about probes. My current way of handling them would be the following :

```yaml
hull:
  config:
    specific:
      probes:
        liveness: ...
  objects:
    deployment:
      my-deployment:
        containers:
          my-container:
            livenessProbe: _HT*hull.config.specific.probes.liveness
```

However, if `hull.config.specific.probes.liveness` is `{}`, I get an error, as the probe is invalid according to Kubernetes. If it is `null`, I get another error, but from the helm linter, as `null` is not allowed in the JSONschema.

Of course, hull provides a workaround : let the user declare their probes directly in `hull.objects`. I could go with this solution, but I think it may not be a bad idea to authorize `null` values in Probes in the JSONschema.